### PR TITLE
3-in-1: restoration, non-meeting interactions, consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Barcelona on Rails is dedicated to providing a harassment-free user group experience for everyone, regardless of sex, sexual orientation, gender identity, disability, physical appearance, body size, race, religion or nationality. We do not tolerate harassment of participants in any form.
 
-Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
+Harassment includes offensive verbal comments related to sex, sexual orientation, gender identity, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
 
 Sexual language and imagery is not appropriate for any meeting or user group venue, including talks. Be careful in the words that you choose. Do not insult or put down other attendees. Behave civilly. Remember that sexist, racist, and other exclusionary jokes can be offensive to those around you. Offensive statements or jokes are not appropriate for the meetings of our user group.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Barcelona on Rails is dedicated to providing a harassment-free user group experi
 
 Harassment includes offensive verbal comments related to sex, sexual orientation, gender identity, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
 
-Sexual language and imagery is not appropriate for any meeting or user group venue, including talks. Be careful in the words that you choose. Do not insult or put down other attendees. Behave civilly. Remember that sexist, racist, and other exclusionary jokes can be offensive to those around you. Offensive statements or jokes are not appropriate for the meetings of our user group.
+Sexual language and imagery is not appropriate for any meeting or user group venue, including talks. Be careful in the words that you choose. Do not insult or put down other attendees. Behave civilly. Remember that sexist, racist, and other exclusionary jokes can be offensive to those around you. Offensive statements or jokes are not appropriate for the meetings and discussions of our user group.
 
 Be kind to others.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Sexual language and imagery is not appropriate for any meeting or user group ven
 Be kind to others.
 
 Participants asked to stop any harassing behavior are expected to comply immediately.
-Anyone violating these rules repeatedly or unapologetically will be asked to leave the meeting, and will be refused entrance to future meetings.
+Anyone violating these rules repeatedly or unapologetically will be asked to leave the meeting, and may be refused entrance to future meetings.
 
 ## credit where credit is due
 


### PR DESCRIPTION
Three small suggestions:

1. [x] Change "will" to "may" to leave room for a restorative process later.  I think this is important because some CoCs are really strict and the people using them even stricter, saying that their organisation will be ruled by the CoC alone, and that saying that we will ban somebody is also an irrevocable promise to the victims of that person.  I want to leave room for kicking someone out and letting them back in when they see the error in their ways.
1. [x] Add "and discussions" to underline that the rules don't apply only at the events.
1. [x] I think it's a good idea to change "gender" to "sex"+"gender identity" but I think we should be consistent.